### PR TITLE
Enabling to switch github repository in zenoss 4.2.4 ubuntu install script

### DIFF
--- a/core-autodeploy/4.2.4/misc/variables.sh
+++ b/core-autodeploy/4.2.4/misc/variables.sh
@@ -4,7 +4,7 @@
 ###############
 
 # REPO is the github repository from which the script is being used
-REPO='hydruid/zenoss'
+REPO='hydruid/zenoss/master'
 
 ### CURRENT SECTION ###
 # Path Variables
@@ -92,7 +92,7 @@ fi	}
 
 debian-testing-repo () {
 cp /etc/apt/sources.list /etc/apt/sources.list.orig
-wget -N https://raw.github.com/${REPO}/master/core-autodeploy/4.2.4/misc/debian-testing-repo.list -P /root/
+wget -N https://raw.github.com/${REPO}/core-autodeploy/4.2.4/misc/debian-testing-repo.list -P /root/
 mv /root/debian-testing-repo.list /etc/apt/sources.list
 apt-get update
 apt-get -t testing install libc6 libc6-dev -y
@@ -114,7 +114,7 @@ if grep -Fxq "Ubuntu 13.04" /etc/issue.net
 elif grep -Fxq "Ubuntu 13.10" /etc/issue.net
 	then	cd /usr/local/zenoss/lib/python/pynetsnmp
 		mv netsnmp.py netsnmp.py.orig
-		wget https://raw.github.com/${REPO}/master/core-autodeploy/4.2.4/misc/netsnmp.py
+		wget https://raw.github.com/${REPO}/core-autodeploy/4.2.4/misc/netsnmp.py
 		chown zenoss:zenoss netsnmp.py
 		echo "...Specific OS fixes complete."
 elif grep -Fxq "Ubuntu 12.04.3 LTS" /etc/issue.net

--- a/core-autodeploy/4.2.4/zenoss-4.2.4_ubuntu-amd64.sh
+++ b/core-autodeploy/4.2.4/zenoss-4.2.4_ubuntu-amd64.sh
@@ -8,7 +8,7 @@
 ##########################################
 
 # REPO is the github repository from which the script is being used
-REPO='hydruid/zenoss'
+REPO='hydruid/zenoss/master'
 
 # Beginning Script Message
 clear
@@ -29,7 +29,7 @@ apt-get update && apt-get dist-upgrade -y && apt-get autoremove -y && echo
 echo && useradd -m -U -s /bin/bash zenoss && echo
 mkdir $ZENOSSHOME/zenoss424-srpm_install
 rm -f $ZENOSSHOME/zenoss424-srpm_install/variables.sh
-wget --no-check-certificate -N https://raw.github.com/${REPO}/master/core-autodeploy/4.2.4/misc/variables.sh -P $ZENOSSHOME/zenoss424-srpm_install/
+wget --no-check-certificate -N https://raw.github.com/${REPO}/core-autodeploy/4.2.4/misc/variables.sh -P $ZENOSSHOME/zenoss424-srpm_install/
 . $ZENOSSHOME/zenoss424-srpm_install/variables.sh
 mkdir $ZENHOME && chown -cR zenoss:zenoss $ZENHOME && chown -cR zenoss:zenoss $ZENOSSHOME/.bashrc
 
@@ -67,7 +67,7 @@ fi
 wget -N http://master.dl.sourceforge.net/project/zenossforubuntu/zenoss-core-424-1897_02a_amd64.deb -P $DOWNDIR/
 dpkg -i $DOWNDIR/zenoss-core-424-1897_02a_amd64.deb
 rm -f $ZENOSSHOME/zenoss424-srpm_install/variables.sh
-wget --no-check-certificate -N https://raw.github.com/${REPO}/master/core-autodeploy/4.2.4/misc/variables.sh -P $ZENOSSHOME/zenoss424-srpm_install/
+wget --no-check-certificate -N https://raw.github.com/${REPO}/core-autodeploy/4.2.4/misc/variables.sh -P $ZENOSSHOME/zenoss424-srpm_install/
 chown -R zenoss:zenoss $ZENHOME && chown -R zenoss:zenoss $ZENOSSHOME
 
 # Import the MySQL Database and create users
@@ -136,7 +136,7 @@ ln -s /usr/local/zenoss/zenup /opt
 chmod +x /usr/local/zenoss/zenup/bin/zenup
 echo 'watchdog True' >> $ZENHOME/etc/zenwinperf.conf
 touch $ZENHOME/var/Data.fs && echo
-wget --no-check-certificate -N https://raw2.github.com/${REPO}/master/core-autodeploy/4.2.4/misc/zenoss -P $DOWNDIR/
+wget --no-check-certificate -N https://raw2.github.com/${REPO}/core-autodeploy/4.2.4/misc/zenoss -P $DOWNDIR/
 cp $DOWNDIR/zenoss /etc/init.d/zenoss
 chmod 755 /etc/init.d/zenoss
 update-rc.d zenoss defaults && sleep 2
@@ -160,7 +160,7 @@ chown -c root:zenoss /usr/local/zenoss/bin/nmap
 chmod -c 04750 /usr/local/zenoss/bin/pyraw
 chmod -c 04750 /usr/local/zenoss/bin/zensocket
 chmod -c 04750 /usr/local/zenoss/bin/nmap && echo
-wget --no-check-certificate -N https://raw.github.com/${REPO}/master/core-autodeploy/4.2.4/misc/secure_zenoss_ubuntu.sh -P $ZENHOME/bin
+wget --no-check-certificate -N https://raw.github.com/${REPO}/core-autodeploy/4.2.4/misc/secure_zenoss_ubuntu.sh -P $ZENHOME/bin
 chown -c zenoss:zenoss $ZENHOME/bin/secure_zenoss_ubuntu.sh && chmod -c 0700 $ZENHOME/bin/secure_zenoss_ubuntu.sh
 su -l -c "$ZENHOME/bin/secure_zenoss_ubuntu.sh" zenoss
 echo '#max_allowed_packet=16M' >> /etc/mysql/my.cnf


### PR DESCRIPTION
Hi!

We are trying to fix some issues with the script. We found that to be able to use our fork, it would be easier having this setting.
